### PR TITLE
action to run gomu gomu no gatling in GH workflows

### DIFF
--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -1,5 +1,8 @@
 name: 'Gomu Gomu no Gatling'
 description: 'Run Gomu Gomu no Gatling to benchmark Starknet Sequencers'
+branding:
+  icon: 'activity-circle'
+  color: 'orange'
 inputs:
   config_path:
     description: 'Path to the configuration file'

--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -1,0 +1,13 @@
+name: 'Gomu Gomu no Gatling'
+description: 'Run Gomu Gomu no Gatling to benchmark Starknet Sequencers'
+inputs:
+  config_path:
+    description: 'Path to the configuration file'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - run: cargo build --release
+      shell: bash
+    - run: ./target/release/gatling shoot --c ${{ inputs.config_path }}
+      shell: bash


### PR DESCRIPTION
Solves https://github.com/keep-starknet-strange/gomu-gomu-no-gatling/issues/6

After we publish this action, using it in a workflow would be something like

      - name: Run Gomu Gomu no Gatling Action
        uses: keep-starknet-strange/gomu-gatling-action@v1
        with:
          config_path: 'path/to/config.yaml'