### PR TITLE
Dependancy Changes and Minor refactors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,4 +33,3 @@ rand = { version = "0.8.5", features = ["rand_chacha"] }
 lazy_static = "1.4.0"
 colored = "2.0.4"
 sysinfo = "0.29.8"
-statrs = "0.16.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ futures = "0.3"
 clap = { version = "4.2.7", features = ["derive"] }
 color-eyre = "0.6.2"
 config = "0.13.3"
-dotenv = "0.15.0"
+dotenvy = "0.15.7"
 serde = "1.0.163"
 serde_derive = "1.0.163"
 serde_json = { version = "1.0.96", features = ["preserve_order"] }

--- a/src/actions/shoot.rs
+++ b/src/actions/shoot.rs
@@ -207,7 +207,7 @@ impl GatlingShooter {
 
             std::fs::create_dir_all(&self.config.report.reports_dir)?;
             let writer = std::fs::File::create(report_path)?;
-            serde_json::to_writer(writer, &report.to_json()?)?;
+            serde_json::to_writer(writer, &report.to_json())?;
         }
 
         Ok(())

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,7 +3,7 @@
 // Imports
 use clap::{Args, Parser, Subcommand};
 
-const VERSION_STRING: &str = concat!(env!("CARGO_PKG_VERSION"));
+const VERSION_STRING: &str = env!("CARGO_PKG_VERSION");
 
 /// Main CLI struct
 #[derive(Parser, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@
 extern crate log;
 use clap::Parser;
 use color_eyre::eyre::Result;
-use dotenv::dotenv;
+use dotenvy::dotenv;
 use gatling::{
     actions::shoot::shoot,
     cli::{Cli, Command},

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -4,7 +4,6 @@ use color_eyre::Result;
 
 use serde_json::{json, Value};
 use starknet::providers::{jsonrpc::HttpTransport, JsonRpcClient, Provider};
-use statrs::statistics::Statistics;
 use std::{fmt, sync::Arc};
 
 pub const BLOCK_TIME: u64 = 6;
@@ -143,7 +142,7 @@ fn average_tps(num_tx_per_block: &[u64]) -> f64 {
 }
 
 fn average_tpb(num_tx_per_block: &[u64]) -> f64 {
-    num_tx_per_block.iter().map(|x| *x as f64).mean()
+    num_tx_per_block.iter().sum::<u64>() as f64 / num_tx_per_block.len() as f64
 }
 
 pub fn compute_all_metrics(num_tx_per_block: Vec<u64>) -> Vec<MetricResult> {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,10 +1,10 @@
-use crate::utils::{get_num_tx_per_block, SYSINFO};
+use crate::utils::{get_num_tx_per_block, SysInfo, SYSINFO};
 
 use color_eyre::Result;
 
 use serde_json::{json, Value};
 use starknet::providers::{jsonrpc::HttpTransport, JsonRpcClient, Provider};
-use std::{fmt, sync::Arc};
+use std::{fmt, ops::Deref, sync::Arc};
 
 pub const BLOCK_TIME: u64 = 6;
 
@@ -50,12 +50,9 @@ impl BenchmarkReport {
     pub async fn from_block_range<'a>(
         starknet_rpc: Arc<JsonRpcClient<HttpTransport>>,
         name: String,
-        start_block: u64,
-        end_block: u64,
+        mut start_block: u64,
+        mut end_block: u64,
     ) -> Result<BenchmarkReport> {
-        let mut start_block = start_block;
-        let mut end_block = end_block;
-
         // Whenever possible, skip the first and last blocks from the metrics
         // to make sure all the blocks used for calculating metrics are full
         if end_block - start_block > 2 {
@@ -84,53 +81,59 @@ impl BenchmarkReport {
         Ok(BenchmarkReport { name, metrics })
     }
 
-    pub fn to_json(&self) -> Result<Value> {
+    pub fn to_json(&self) -> Value {
+        let SysInfo {
+            os_name,
+            kernel_version,
+            arch,
+            cpu_count,
+            cpu_frequency,
+            cpu_brand,
+            memory,
+        } = SYSINFO.deref();
+
+        let gigabyte_memory = memory / (1024 * 1024 * 1024);
+
         let sysinfo_string = format!(
-            "CPU Count: {}\n\
-            CPU Model: {}\n\
-            CPU Speed (MHz): {}\n\
-            Total Memory: {} GB\n\
-            Platform: {}\n\
-            Release: {}\n\
-            Architecture: {}",
-            SYSINFO.cpu_count,
-            SYSINFO.cpu_frequency,
-            SYSINFO.cpu_brand,
-            SYSINFO.memory / (1024 * 1024 * 1024),
-            SYSINFO.os_name,
-            SYSINFO.kernel_version,
-            SYSINFO.arch
+            "CPU Count: {cpu_count}\n\
+            CPU Model: {cpu_brand}\n\
+            CPU Speed (MHz): {cpu_frequency}\n\
+            Total Memory: {gigabyte_memory} GB\n\
+            Platform: {os_name}\n\
+            Release: {kernel_version}\n\
+            Architecture: {arch}",
         );
 
-        let mut report = vec![];
-
-        for metric in self.metrics.iter() {
-            report.push(json!({
-                "name": metric.name,
-                "unit": metric.unit,
-                "value": metric.value,
-                "extra": sysinfo_string
-            }));
-        }
-
-        let report_json = serde_json::to_value(report)?;
-
-        Ok(report_json)
+        self.metrics
+            .iter()
+            .map(|metric| {
+                json!({
+                    "name": metric.name,
+                    "unit": metric.unit,
+                    "value": metric.value,
+                    "extra": sysinfo_string
+                })
+            })
+            .collect::<Value>()
     }
 }
 
 impl fmt::Display for MetricResult {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}: {} {}", self.name, self.value, self.unit)
+        let Self { name, value, unit } = self;
+
+        write!(f, "{name}: {value} {unit}")
     }
 }
 
 impl fmt::Display for BenchmarkReport {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "Benchmark Report: {}", self.name)?;
+        let Self { name, metrics } = self;
 
-        for metric in &self.metrics {
-            writeln!(f, "{}", metric)?;
+        writeln!(f, "Benchmark Report: {name}")?;
+
+        for metric in metrics {
+            writeln!(f, "{metric}")?;
         }
 
         Ok(())

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -92,16 +92,26 @@ impl Default for SysInfo {
 
 impl fmt::Display for SysInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            os_name,
+            kernel_version,
+            arch,
+            cpu_count,
+            cpu_frequency,
+            cpu_brand,
+            memory,
+        } = self;
+
+        let cpu_ghz_freq = *cpu_frequency as f64 / 1000.0;
+        let gigabyte_memory = memory / (1024 * 1024 * 1024);
+
         writeln!(
             f,
-            "System Information:\nSystem : {} Kernel Version {}\nArch   : {}\nCPU    : {} {:.2}GHz {} cores\nMemory : {} GB",
-            self.os_name,
-            self.kernel_version,
-            self.arch,
-            self.cpu_brand,
-            format!("{:.2} GHz", self.cpu_frequency as f64 / 1000.0),
-            self.cpu_count,
-            self.memory / (1024 * 1024 * 1024)
+            "System Information:\n\
+            System : {os_name} Kernel Version {kernel_version}\n\
+            Arch   : {arch}\n\
+            CPU    : {cpu_brand} {cpu_ghz_freq:.2} GHz {cpu_count} cores\n\
+            Memory : {gigabyte_memory} GB"
         )
     }
 }


### PR DESCRIPTION
This PR is changes I had made after taking a quick look at the codebase for anything simple to refactor/improve. The changes are listed below:

- Changed`dotenv` to the maintained `dotenvy` fork to fix #17
- Removed `statrs` due to not being mantained and also only being used to calculate a mean
- Removed `Result` from the `BenchmarkReport::to_json` return type after changing the internals to guarantee it won't fail
- Made multiple type's `Display`s destructure `Self` before formatting so that they can be nicely embedded into the string
- Fixed bug where [cpu frequency and brand were mixed up](https://github.com/keep-starknet-strange/gomu-gomu-no-gatling/blob/caa6179bdd440c00041d7abf2e0880f60f43b49b/src/metrics.rs#L98-L99) in `SysInfo` formatting
- Fixed `SysInfo`'s `Display` implementation showing frequency as `3.GHz`  and changed it to show as `3.50 GHz`
- Removed unnecessary `concat!` from `VERSION_STRING`

## Possible Additional Changes
Preferably, `BenchmarkReport::to_json` shouldn't do any formatting of `SysInfo`, if this exact structure isn't necessary we should swap it to just use the `Display` implementation of `SysInfo` via `SYSINFO.to_string()`