### PR TITLE
Add reporting to goose shoot and improve error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,19 +112,21 @@ At the end of all benchmarks gomu gomu will collect the results into a single js
 
 - `users`: The amount of goose users used to do the benchmarks, changed by `concurrency`
 
-- `all_bench_report`: A report over all benchmarks done
+- `all_bench_report`: A report over all benchmarks done, has a portion of metrics that `benches` has
 
 - `benches`: A array of reports for all benchmarks
 
   - `name`: The name of the benchmark
   - `amount`: How many times this benchmark was ran
-  - `metrics`: An array of metrics over the whole benchmark
+  - `metrics`: Metrics over the whole benchmark
 
     - `name`: The name of the metric
     - `unit`: The unit of the metric, empty when there is no unit
     - `value`: The metrics value, a number
 
       - For floats, `Infinite` and `NaN` are not JSON numbers and thus will be turned into `null`
+      - Values gotten from submission time are calculated from the latency to add a new transaction to the node
+      - Values gotten from verification time are calculated from the latency to get the transaction receipt after the transactions have been processed
 
   - `last_x_blocks_metrics`: Metrics over the last blocks of the benchmark
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The configuration is defined by the following spec
 - `report`
 
   - `num_blocks`: Number of last blocks to take into account in the report
-  - `location`: Path to the file where to save the reports
+  - `output_location`: Path to the file where to save the reports
 
 - `deployer`
 
@@ -106,7 +106,7 @@ gatling shoot -c config/default.yaml
 
 ### Output
 
-The main output of gomu gomu is the report location specified in specified in the configuration file.
+The main output of gomu gomu is the report output location specified in specified in the configuration file.
 
 At the end of all benchmarks gomu gomu will collect the results into a single json file with the following structure:
 

--- a/README.md
+++ b/README.md
@@ -115,21 +115,23 @@ At the end of all benchmarks gomu gomu will collect the results into a single js
 - `all_bench_report`: A report over all benchmarks done
 
 - `benches`: A array of reports for all benchmarks
-  
+
   - `name`: The name of the benchmark
   - `amount`: How many times this benchmark was ran
-  - `metrics`: An array of benchmark metrics over the whole benchmark
+  - `metrics`: An array of metrics over the whole benchmark
 
     - `name`: The name of the metric
     - `unit`: The unit of the metric, empty when there is no unit
     - `value`: The metrics value, a number
-    
+
       - For floats, `Infinite` and `NaN` are not JSON numbers and thus will be turned into `null`
 
-  - `last_x_blocks_metrics`: An array of benchmark metrics over the last metrics, changed by `num_blocks`
+  - `last_x_blocks_metrics`: Metrics over the last blocks of the benchmark
+
+    - `num_blocks`: The amount of last transactions that were measured
+    - `metrics`: An array of metrics
 
 - `extra`: Extra information for this run
-
 
 Gomu gomu will also display into the console information about each step in the benchmark.
 

--- a/README.md
+++ b/README.md
@@ -85,11 +85,12 @@ The configuration is defined by the following spec
 
   - `num_erc20_transfers`: Number of ERC20 `transfer` transactions
   - `num_erc721_mints`: Number of ERC721 `mint` transactions
+  - `concurrency`: How many transactions to do simultaneously
 
 - `report`
 
   - `num_blocks`: Number of last blocks to take into account in the report
-  - `reports_dir`: Path to the directory where to save the reports
+  - `location`: Path to the file where to save the reports
 
 - `deployer`
 
@@ -102,6 +103,35 @@ The configuration is defined by the following spec
 ```bash
 gatling shoot -c config/default.yaml
 ```
+
+### Output
+
+The main output of gomu gomu is the report location specified in specified in the configuration file.
+
+At the end of all benchmarks gomu gomu will collect the results into a single json file with the following structure:
+
+- `users`: The amount of goose users used to do the benchmarks, changed by `concurrency`
+
+- `all_bench_report`: A report over all benchmarks done
+
+- `benches`: A array of reports for all benchmarks
+  
+  - `name`: The name of the benchmark
+  - `amount`: How many times this benchmark was ran
+  - `metrics`: An array of benchmark metrics over the whole benchmark
+
+    - `name`: The name of the metric
+    - `unit`: The unit of the metric, empty when there is no unit
+    - `value`: The metrics value, a number
+    
+      - For floats, `Infinite` and `NaN` are not JSON numbers and thus will be turned into `null`
+
+  - `last_x_blocks_metrics`: An array of benchmark metrics over the last metrics, changed by `num_blocks`
+
+- `extra`: Extra information for this run
+
+
+Gomu gomu will also display into the console information about each step in the benchmark.
 
 ## Resources
 

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -22,7 +22,7 @@ run:
 
 report:
   num_blocks: 4
-  reports_dir: "reports"
+  location: "report"
 
 deployer:
   salt: "1"

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -22,7 +22,7 @@ run:
 
 report:
   num_blocks: 4
-  location: "report"
+  output_location: "report"
 
 deployer:
   salt: "1"

--- a/config/katana.yaml
+++ b/config/katana.yaml
@@ -22,7 +22,7 @@ run:
 
 report:
   num_blocks: 4
-  reports_dir: "reports"
+  location: "report"
 
 deployer:
   salt: "1"

--- a/config/katana.yaml
+++ b/config/katana.yaml
@@ -22,7 +22,7 @@ run:
 
 report:
   num_blocks: 4
-  location: "report"
+  output_location: "report"
 
 deployer:
   salt: "1"

--- a/config/sharingan.yaml
+++ b/config/sharingan.yaml
@@ -22,7 +22,7 @@ run:
 
 report:
   num_blocks: 4
-  reports_dir: "reports"
+  location: "report"
 
 # need to add an adress and signing key on sharingan network
 deployer:

--- a/config/sharingan.yaml
+++ b/config/sharingan.yaml
@@ -22,7 +22,7 @@ run:
 
 report:
   num_blocks: 4
-  location: "report"
+  output_location: "report"
 
 # need to add an adress and signing key on sharingan network
 deployer:

--- a/config/v2.1.0.yaml
+++ b/config/v2.1.0.yaml
@@ -28,7 +28,7 @@ run:
 
 report:
   num_blocks: 3
-  location: "report"
+  output_location: "report"
 
 deployer:
   salt: "1"

--- a/config/v2.1.0.yaml
+++ b/config/v2.1.0.yaml
@@ -28,7 +28,7 @@ run:
 
 report:
   num_blocks: 3
-  reports_dir: "reports"
+  location: "report"
 
 deployer:
   salt: "1"

--- a/src/actions/goose.rs
+++ b/src/actions/goose.rs
@@ -358,7 +358,7 @@ async fn verify_transactions(user: &mut GooseUser) -> TransactionResult {
                 ExecutionResult::Reverted { reason } => {
                     let tag = format!("Transaction {tx:#064x} has been rejected/reverted");
 
-                    user.set_failure(&tag, &mut metrics, None, Some(reason))?;
+                    return user.set_failure(&tag, &mut metrics, None, Some(reason));
                 }
             },
             MaybePendingTransactionReceipt::PendingReceipt(pending) => {
@@ -366,7 +366,7 @@ async fn verify_transactions(user: &mut GooseUser) -> TransactionResult {
                     format!("Transaction {tx:#064x} is pending when no transactions should be");
                 let body = format!("{pending:?}");
 
-                user.set_failure(&tag, &mut metrics, None, Some(&body))?;
+                return user.set_failure(&tag, &mut metrics, None, Some(&body));
             }
         }
     }
@@ -388,7 +388,7 @@ pub async fn wait_for_tx(
 
         if start.elapsed().unwrap() >= WAIT_FOR_TX_TIMEOUT {
             let tag = format!("Timeout while waiting for transaction {tx_hash:#064x}");
-            user.set_failure(&tag, &mut metrics, None, None)?;
+            return user.set_failure(&tag, &mut metrics, None, None);
         }
 
         match receipt {
@@ -410,7 +410,7 @@ pub async fn wait_for_tx(
                             "Transaction {tx_hash:#064x} has been rejected/reverted: {reason}"
                         );
 
-                        user.set_failure(&tag, &mut metrics, None, None)?;
+                        return user.set_failure(&tag, &mut metrics, None, None);
                     }
                 }
             }
@@ -422,7 +422,7 @@ pub async fn wait_for_tx(
                     let tag =
                         format!("Transaction {tx_hash:#064x} has been rejected/reverted: {reason}");
 
-                    user.set_failure(&tag, &mut metrics, None, None)?;
+                    return user.set_failure(&tag, &mut metrics, None, None);
                 }
                 log::debug!("Waiting for transaction {tx_hash:#064x} to be accepted");
                 tokio::time::sleep(CHECK_INTERVAL).await;
@@ -442,7 +442,7 @@ pub async fn wait_for_tx(
                     "Error Code {code} while waiting for transaction {tx_hash:#064x}: {message}"
                 );
 
-                user.set_failure(&tag, &mut metrics, None, None)?;
+                return user.set_failure(&tag, &mut metrics, None, None);
             }
         }
     }

--- a/src/actions/goose.rs
+++ b/src/actions/goose.rs
@@ -14,7 +14,6 @@ use starknet::{
     },
     core::types::{
         ExecutionResult, FieldElement, InvokeTransactionResult, MaybePendingTransactionReceipt,
-        StarknetError,
     },
     macros::{felt, selector},
     providers::{
@@ -393,6 +392,8 @@ pub async fn wait_for_tx(
 
         let reverted_tag = || format!("Transaction {tx_hash:#064x} has been rejected/reverted");
 
+        const TRANSACTION_HASH_NOT_FOUND: i64 = 29;
+
         match receipt {
             JsonRpcResponse::Success {
                 result: MaybePendingTransactionReceipt::Receipt(receipt),
@@ -423,9 +424,13 @@ pub async fn wait_for_tx(
                 tokio::time::sleep(CHECK_INTERVAL).await;
             }
             JsonRpcResponse::Error {
-                error: JsonRpcError { code, .. },
+                error:
+                    JsonRpcError {
+                        code: TRANSACTION_HASH_NOT_FOUND,
+                        ..
+                    },
                 ..
-            } if code == StarknetError::TransactionHashNotFound as i64 => {
+            } => {
                 log::debug!("Waiting for transaction {tx_hash:#064x} to show up");
                 tokio::time::sleep(CHECK_INTERVAL).await;
             }

--- a/src/actions/goose.rs
+++ b/src/actions/goose.rs
@@ -1,8 +1,12 @@
-use std::{mem, sync::Arc};
+use std::{
+    mem,
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
 
 use color_eyre::eyre::ensure;
 use crossbeam_queue::ArrayQueue;
-use goose::{config::GooseConfiguration, prelude::*};
+use goose::{config::GooseConfiguration, metrics::GooseRequestMetric, prelude::*};
 use serde::{de::DeserializeOwned, Serialize};
 use starknet::{
     accounts::{
@@ -10,11 +14,13 @@ use starknet::{
     },
     core::types::{
         ExecutionResult, FieldElement, InvokeTransactionResult, MaybePendingTransactionReceipt,
+        StarknetError,
     },
     macros::{felt, selector},
     providers::{
         jsonrpc::{
-            HttpTransport, HttpTransportError, JsonRpcClientError, JsonRpcMethod, JsonRpcResponse,
+            HttpTransport, HttpTransportError, JsonRpcClientError, JsonRpcError, JsonRpcMethod,
+            JsonRpcResponse,
         },
         JsonRpcClient, ProviderError,
     },
@@ -24,12 +30,11 @@ use starknet::{
 use crate::{
     actions::shoot::{GatlingShooterSetup, CHECK_INTERVAL, MAX_FEE},
     generators::get_rng,
-    utils::wait_for_tx,
 };
 
 use super::shoot::StarknetAccount;
 
-pub async fn erc20(shooter: &GatlingShooterSetup) -> color_eyre::Result<()> {
+pub async fn erc20(shooter: &GatlingShooterSetup) -> color_eyre::Result<GooseMetrics> {
     let environment = shooter.environment()?;
     let erc20_address = environment.erc20_address;
     let config = shooter.config();
@@ -66,9 +71,9 @@ pub async fn erc20(shooter: &GatlingShooterSetup) -> color_eyre::Result<()> {
     let transfer: TransactionFunction =
         Arc::new(move |user| Box::pin(transfer(user, erc20_address)));
 
-    let transfer_wait: TransactionFunction = goose_user_wait_last_tx(shooter.rpc_client().clone());
+    let transfer_wait: TransactionFunction = goose_user_wait_last_tx();
 
-    GooseAttack::initialize_with_config(goose_config.clone())?
+    let metrics = GooseAttack::initialize_with_config(goose_config.clone())?
         .register_scenario(
             scenario!("Transfer")
                 .register_transaction(
@@ -89,7 +94,7 @@ pub async fn erc20(shooter: &GatlingShooterSetup) -> color_eyre::Result<()> {
                 )
                 .register_transaction(
                     transaction!(verify_transactions)
-                        .set_name("Transfer Verification")
+                        .set_name("Verification")
                         .set_sequence(3)
                         .set_on_stop(),
                 ),
@@ -97,10 +102,10 @@ pub async fn erc20(shooter: &GatlingShooterSetup) -> color_eyre::Result<()> {
         .execute()
         .await?;
 
-    Ok(())
+    Ok(metrics)
 }
 
-pub async fn erc721(shooter: &GatlingShooterSetup) -> color_eyre::Result<()> {
+pub async fn erc721(shooter: &GatlingShooterSetup) -> color_eyre::Result<GooseMetrics> {
     let config = shooter.config();
     let environment = shooter.environment()?;
 
@@ -154,9 +159,9 @@ pub async fn erc721(shooter: &GatlingShooterSetup) -> color_eyre::Result<()> {
         Box::pin(async move { mint(user, erc721_address, nonce, &from_account).await })
     });
 
-    let mint_wait: TransactionFunction = goose_user_wait_last_tx(shooter.rpc_client().clone());
+    let mint_wait: TransactionFunction = goose_user_wait_last_tx();
 
-    GooseAttack::initialize_with_config(goose_mint_config.clone())?
+    let metrics = GooseAttack::initialize_with_config(goose_mint_config.clone())?
         .register_scenario(
             scenario!("Minting")
                 .register_transaction(
@@ -173,7 +178,7 @@ pub async fn erc721(shooter: &GatlingShooterSetup) -> color_eyre::Result<()> {
                 )
                 .register_transaction(
                     transaction!(verify_transactions)
-                        .set_name("Mint Verification")
+                        .set_name("Verification")
                         .set_sequence(3)
                         .set_on_stop(),
                 ),
@@ -181,7 +186,7 @@ pub async fn erc721(shooter: &GatlingShooterSetup) -> color_eyre::Result<()> {
         .execute()
         .await?;
 
-    Ok(())
+    Ok(metrics)
 }
 
 #[derive(Debug, Clone)]
@@ -230,21 +235,20 @@ async fn setup(
     }))
 }
 
-fn goose_user_wait_last_tx(provider: Arc<JsonRpcClient<HttpTransport>>) -> TransactionFunction {
+fn goose_user_wait_last_tx() -> TransactionFunction {
     Arc::new(move |user| {
-        let thing = user
+        let tx = user
             .get_session_data::<GooseUserState>()
             .expect("Should be in a goose user with GooseUserState session data")
             .prev_tx
             .last()
-            .expect("At least one transaction should have been done");
-
-        let provider = provider.clone();
+            .copied();
 
         Box::pin(async move {
-            wait_for_tx(&provider, *thing, CHECK_INTERVAL)
-                .await
-                .expect("Transaction should have been successful");
+            // If all transactions failed, we can skip this step
+            if let Some(tx) = tx {
+                wait_for_tx(user, tx).await?;
+            }
 
             Ok(())
         })
@@ -280,7 +284,8 @@ async fn transfer(user: &mut GooseUser, erc20_address: FieldElement) -> Transact
         &account.clone(),
         JsonRpcMethod::AddInvokeTransaction,
     )
-    .await?;
+    .await?
+    .0;
 
     let GooseUserState { nonce, prev_tx, .. } =
         user.get_session_data_mut::<GooseUserState>().expect(
@@ -322,7 +327,8 @@ async fn mint(
         from_account,
         JsonRpcMethod::AddInvokeTransaction,
     )
-    .await?;
+    .await?
+    .0;
 
     user.get_session_data_mut::<GooseUserState>()
         .expect(
@@ -343,23 +349,103 @@ async fn verify_transactions(user: &mut GooseUser) -> TransactionResult {
     );
 
     for tx in transactions {
-        let receipt: MaybePendingTransactionReceipt =
+        let (receipt, mut metrics) =
             send_request(user, JsonRpcMethod::GetTransactionReceipt, tx).await?;
 
         match receipt {
             MaybePendingTransactionReceipt::Receipt(receipt) => match receipt.execution_result() {
                 ExecutionResult::Succeeded => {}
                 ExecutionResult::Reverted { reason } => {
-                    panic!("Transaction {tx:#064x} has been rejected/reverted: {reason}");
+                    let tag = format!("Transaction {tx:#064x} has been rejected/reverted");
+
+                    user.set_failure(&tag, &mut metrics, None, Some(reason))?;
                 }
             },
-            MaybePendingTransactionReceipt::PendingReceipt(_) => {
-                panic!("Transaction {tx:#064x} is pending when no transactions should be")
+            MaybePendingTransactionReceipt::PendingReceipt(pending) => {
+                let tag =
+                    format!("Transaction {tx:#064x} is pending when no transactions should be");
+                let body = format!("{pending:?}");
+
+                user.set_failure(&tag, &mut metrics, None, Some(&body))?;
             }
         }
     }
 
     Ok(())
+}
+
+const WAIT_FOR_TX_TIMEOUT: Duration = Duration::from_secs(60);
+
+pub async fn wait_for_tx(
+    user: &mut GooseUser,
+    tx_hash: FieldElement,
+) -> Result<(), Box<TransactionError>> {
+    let start = SystemTime::now();
+
+    loop {
+        let (receipt, mut metrics) =
+            raw_send_request(user, JsonRpcMethod::GetTransactionReceipt, tx_hash).await?;
+
+        if start.elapsed().unwrap() >= WAIT_FOR_TX_TIMEOUT {
+            let tag = format!("Timeout while waiting for transaction {tx_hash:#064x}");
+            user.set_failure(&tag, &mut metrics, None, None)?;
+        }
+
+        match receipt {
+            JsonRpcResponse::Success {
+                result: MaybePendingTransactionReceipt::Receipt(receipt),
+                ..
+            } => {
+                // Logic copied from starkli and the following comment too
+                // tWith JSON-RPC, once we get a receipt, the transaction must have been confirmed.
+                // Rejected transactions simply aren't available. This needs to be changed once we
+                // implement the sequencer fallback.
+
+                match receipt.execution_result() {
+                    ExecutionResult::Succeeded => {
+                        return Ok(());
+                    }
+                    ExecutionResult::Reverted { reason } => {
+                        let tag = format!(
+                            "Transaction {tx_hash:#064x} has been rejected/reverted: {reason}"
+                        );
+
+                        user.set_failure(&tag, &mut metrics, None, None)?;
+                    }
+                }
+            }
+            JsonRpcResponse::Success {
+                result: MaybePendingTransactionReceipt::PendingReceipt(pending),
+                ..
+            } => {
+                if let ExecutionResult::Reverted { reason } = pending.execution_result() {
+                    let tag =
+                        format!("Transaction {tx_hash:#064x} has been rejected/reverted: {reason}");
+
+                    user.set_failure(&tag, &mut metrics, None, None)?;
+                }
+                log::debug!("Waiting for transaction {tx_hash:#064x} to be accepted");
+                tokio::time::sleep(CHECK_INTERVAL).await;
+            }
+            JsonRpcResponse::Error {
+                error: JsonRpcError { code, .. },
+                ..
+            } if code == StarknetError::TransactionHashNotFound as i64 => {
+                log::debug!("Waiting for transaction {tx_hash:#064x} to show up");
+                tokio::time::sleep(CHECK_INTERVAL).await;
+            }
+            JsonRpcResponse::Error {
+                error: JsonRpcError { code, message },
+                ..
+            } => {
+                let tag = format!(
+                    "Error Code {code} while waiting for transaction {tx_hash:#064x}: {message}"
+                );
+
+                user.set_failure(&tag, &mut metrics, None, None)?;
+            }
+        }
+    }
 }
 
 pub async fn send_execution<T: DeserializeOwned>(
@@ -368,7 +454,7 @@ pub async fn send_execution<T: DeserializeOwned>(
     nonce: FieldElement,
     from_account: &SingleOwnerAccount<Arc<JsonRpcClient<HttpTransport>>, LocalWallet>,
     method: JsonRpcMethod,
-) -> Result<T, Box<TransactionError>> {
+) -> Result<(T, GooseRequestMetric), Box<TransactionError>> {
     let calldata = from_account.encode_calls(&calls);
 
     #[allow(dead_code)] // Removes warning for unused fields, we need them to properly transmute
@@ -407,7 +493,30 @@ pub async fn send_request<T: DeserializeOwned>(
     user: &mut GooseUser,
     method: JsonRpcMethod,
     param: impl Serialize,
-) -> Result<T, Box<TransactionError>> {
+) -> Result<(T, GooseRequestMetric), Box<TransactionError>> {
+    let (body, mut metrics) = raw_send_request(user, method, param).await?;
+
+    match body {
+        JsonRpcResponse::Success { result, .. } => Ok((result, metrics)),
+        JsonRpcResponse::Error { error, .. } => {
+            // While this is not the actual body we cannot serialize `JsonRpcResponse`
+            // due to it not implementing `Serialize`, and if we were to get the text before
+            // serializing we couldn't map the serde_json error to `TransactionError`.
+            // It also provides the exact same info and this is just debug information
+            let error = error.to_string();
+
+            Err(user
+                .set_failure("RPC Response was Error", &mut metrics, None, Some(&error))
+                .unwrap_err()) // SAFETY: This always returns a error
+        }
+    }
+}
+
+pub async fn raw_send_request<T: DeserializeOwned>(
+    user: &mut GooseUser,
+    method: JsonRpcMethod,
+    param: impl Serialize,
+) -> Result<(JsonRpcResponse<T>, GooseRequestMetric), Box<TransactionError>> {
     // Copied from https://docs.rs/starknet-providers/0.9.0/src/starknet_providers/jsonrpc/transports/http.rs.html#21-27
     #[derive(Debug, Serialize)]
     struct JsonRpcRequest<T> {
@@ -424,20 +533,14 @@ pub async fn send_request<T: DeserializeOwned>(
         params: [param],
     };
 
-    let body = user
-        .post_json("/", &request)
-        .await?
+    let goose_response = user.post_json("/", &request).await?;
+
+    let body = goose_response
         .response
         .map_err(TransactionError::Reqwest)?
         .json::<JsonRpcResponse<T>>()
         .await
         .map_err(TransactionError::Reqwest)?;
 
-    match body {
-        JsonRpcResponse::Success { result, .. } => Ok(result),
-        // Returning this error would probably be a good idea,
-        // but the goose error type doesn't allow it and we are
-        // required to return it as a constraint of TransactionFunction
-        JsonRpcResponse::Error { error, .. } => panic!("{error}"),
-    }
+    Ok((body, goose_response.request))
 }

--- a/src/actions/goose.rs
+++ b/src/actions/goose.rs
@@ -398,16 +398,14 @@ pub async fn wait_for_tx(
             JsonRpcResponse::Success {
                 result: MaybePendingTransactionReceipt::Receipt(receipt),
                 ..
-            } => {
-                match receipt.execution_result() {
-                    ExecutionResult::Succeeded => {
-                        return Ok(());
-                    }
-                    ExecutionResult::Reverted { reason } => {
-                        return user.set_failure(&reverted_tag(), &mut metric, None, Some(reason));
-                    }
+            } => match receipt.execution_result() {
+                ExecutionResult::Succeeded => {
+                    return Ok(());
                 }
-            }
+                ExecutionResult::Reverted { reason } => {
+                    return user.set_failure(&reverted_tag(), &mut metric, None, Some(reason));
+                }
+            },
             JsonRpcResponse::Success {
                 result: MaybePendingTransactionReceipt::PendingReceipt(pending),
                 ..

--- a/src/actions/goose.rs
+++ b/src/actions/goose.rs
@@ -399,11 +399,6 @@ pub async fn wait_for_tx(
                 result: MaybePendingTransactionReceipt::Receipt(receipt),
                 ..
             } => {
-                // Logic copied from starkli and the following comment too
-                // tWith JSON-RPC, once we get a receipt, the transaction must have been confirmed.
-                // Rejected transactions simply aren't available. This needs to be changed once we
-                // implement the sequencer fallback.
-
                 match receipt.execution_result() {
                     ExecutionResult::Succeeded => {
                         return Ok(());

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -65,7 +65,11 @@ pub async fn shoot(config: GatlingConfig) -> color_eyre::Result<()> {
         .with_block_range(shooter.rpc_client(), start_block, end_block)
         .await?;
 
-    let report_path = shooter.config().report.output_location.with_extension("json");
+    let report_path = shooter
+        .config()
+        .report
+        .output_location
+        .with_extension("json");
 
     let writer = std::fs::File::create(report_path)?;
     serde_json::to_writer_pretty(writer, &global_report)?;

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -65,7 +65,7 @@ pub async fn shoot(config: GatlingConfig) -> color_eyre::Result<()> {
         .with_block_range(shooter.rpc_client(), start_block, end_block)
         .await?;
 
-    let report_path = shooter.config().report.location.with_extension("json");
+    let report_path = shooter.config().report.output_location.with_extension("json");
 
     let writer = std::fs::File::create(report_path)?;
     serde_json::to_writer_pretty(writer, &global_report)?;

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -1,4 +1,9 @@
-use crate::config::GatlingConfig;
+use starknet::providers::Provider;
+
+use crate::{
+    config::GatlingConfig,
+    metrics::{BenchmarkReport, WholeReport},
+};
 
 use self::shoot::GatlingShooterSetup;
 
@@ -9,20 +14,81 @@ pub async fn shoot(config: GatlingConfig) -> color_eyre::Result<()> {
     let run_erc20 = config.run.num_erc20_transfers != 0;
     let run_erc721 = config.run.num_erc721_mints != 0;
 
-    let mut shooter = GatlingShooterSetup::from_config(config).await?;
+    let mut shooter = GatlingShooterSetup::from_config(config.clone()).await?;
     shooter.setup().await?;
 
+    let mut whole_report = WholeReport {
+        users: shooter.config().run.concurrency,
+        all_bench_report: BenchmarkReport::new(
+            "",
+            (config.run.num_erc20_transfers + config.run.num_erc721_mints) as usize,
+        ),
+        benches: Vec::new(),
+        extra: crate::utils::sysinfo_string(),
+    };
+
+    let start_block = shooter.rpc_client().block_number().await?;
+
     if run_erc20 {
-        goose::erc20(&shooter).await?;
+        let start_block = shooter.rpc_client().block_number().await?;
+        let goose_metrics = goose::erc20(&shooter).await?;
+        let end_block = shooter.rpc_client().block_number().await?;
+
+        let mut report =
+            BenchmarkReport::new("Erc20 Transfers", goose_metrics.scenarios[0].counter);
+
+        report
+            .with_block_range(shooter.rpc_client(), start_block + 1, end_block)
+            .await?;
+
+        if config.report.num_blocks != 0 {
+            report
+                .with_last_x_blocks(shooter.rpc_client(), config.report.num_blocks)
+                .await?;
+        }
+
+        report.with_goose_metrics(&goose_metrics)?;
+
+        whole_report.benches.push(report);
     } else {
         log::info!("Skipping erc20 transfers")
     }
 
     if run_erc721 {
-        goose::erc721(&shooter).await?;
+        let start_block = shooter.rpc_client().block_number().await?;
+        let goose_metrics = goose::erc721(&shooter).await?;
+        let end_block = shooter.rpc_client().block_number().await?;
+
+        let mut report = BenchmarkReport::new("Erc721 Mints", goose_metrics.scenarios[0].counter);
+
+        report
+            .with_block_range(shooter.rpc_client(), start_block + 1, end_block)
+            .await?;
+
+        if config.report.num_blocks != 0 {
+            report
+                .with_last_x_blocks(shooter.rpc_client(), config.report.num_blocks)
+                .await?;
+        }
+
+        report.with_goose_metrics(&goose_metrics)?;
+
+        whole_report.benches.push(report);
     } else {
         log::info!("Skipping erc721 mints")
     }
+
+    let end_block = shooter.rpc_client().block_number().await?;
+
+    whole_report
+        .all_bench_report
+        .with_block_range(shooter.rpc_client(), start_block, end_block)
+        .await?;
+
+    let report_path = shooter.config().report.location.with_extension("json");
+
+    let writer = std::fs::File::create(report_path)?;
+    serde_json::to_writer_pretty(writer, &whole_report)?;
 
     Ok(())
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -111,7 +111,7 @@ pub struct RunConfig {
 #[derive(Debug, Deserialize, Clone)]
 pub struct ReportConfig {
     pub num_blocks: u64,
-    pub location: PathBuf,
+    pub output_location: PathBuf,
 }
 
 impl GatlingConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -111,7 +111,7 @@ pub struct RunConfig {
 #[derive(Debug, Deserialize, Clone)]
 pub struct ReportConfig {
     pub num_blocks: u64,
-    pub reports_dir: PathBuf,
+    pub location: PathBuf,
 }
 
 impl GatlingConfig {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -171,7 +171,7 @@ impl BenchmarkReport {
                 value: requests.min_time.into(),
             },
             MetricResult {
-                name: "Mean Submission Time",
+                name: "Average Submission Time",
                 unit: "milliseconds",
                 value: (requests.total_time as f64 / scenario.counter as f64).into(),
             },
@@ -186,7 +186,7 @@ impl BenchmarkReport {
                 value: verification_requests.raw_data.minimum_time.into(),
             },
             MetricResult {
-                name: "Mean Verification Time",
+                name: "Average Verification Time",
                 unit: "milliseconds",
                 value: (verification_requests.raw_data.total_time as f64 / scenario.counter as f64)
                     .into(),

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -134,15 +134,17 @@ impl BenchmarkReport {
             .get("POST Verification")
             .ok_or(eyre!("Found no verification request metrics"))?;
 
+        const GOOSE_TIME_UNIT: &str = "milliseconds";
+
         self.metrics.extend_from_slice(&[
             MetricResult {
                 name: "Total Submission Time",
-                unit: "milliseconds",
+                unit: GOOSE_TIME_UNIT,
                 value: requests.total_time.into(),
             },
             MetricResult {
                 name: "Total Verification Time",
-                unit: "milliseconds",
+                unit: GOOSE_TIME_UNIT,
                 value: verification.total_time.into(),
             },
             MetricResult {
@@ -157,32 +159,32 @@ impl BenchmarkReport {
             },
             MetricResult {
                 name: "Max Submission Time",
-                unit: "milliseconds",
+                unit: GOOSE_TIME_UNIT,
                 value: requests.max_time.into(),
             },
             MetricResult {
                 name: "Min Submission Time",
-                unit: "milliseconds",
+                unit: GOOSE_TIME_UNIT,
                 value: requests.min_time.into(),
             },
             MetricResult {
                 name: "Average Submission Time",
-                unit: "milliseconds",
+                unit: GOOSE_TIME_UNIT,
                 value: transaction_average(requests).into(),
             },
             MetricResult {
                 name: "Max Verification Time",
-                unit: "milliseconds",
+                unit: GOOSE_TIME_UNIT,
                 value: verification_requests.raw_data.maximum_time.into(),
             },
             MetricResult {
                 name: "Min Verification Time",
-                unit: "milliseconds",
+                unit: GOOSE_TIME_UNIT,
                 value: verification_requests.raw_data.minimum_time.into(),
             },
             MetricResult {
                 name: "Average Verification Time",
-                unit: "milliseconds",
+                unit: GOOSE_TIME_UNIT,
                 value: transaction_average(requests).into(),
             },
         ]);

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,12 +1,24 @@
-use crate::utils::{get_num_tx_per_block, SysInfo, SYSINFO};
+use crate::utils::get_num_tx_per_block;
 
-use color_eyre::Result;
+use color_eyre::{
+    eyre::{bail, eyre},
+    Result,
+};
 
-use serde_json::{json, Value};
+use goose::metrics::GooseMetrics;
+use serde_derive::Serialize;
 use starknet::providers::{jsonrpc::HttpTransport, JsonRpcClient, Provider};
-use std::{fmt, ops::Deref, sync::Arc};
+use std::fmt;
 
 pub const BLOCK_TIME: u64 = 6;
+
+#[derive(Clone, Debug, Serialize)]
+pub struct WholeReport {
+    pub users: u64,
+    pub all_bench_report: BenchmarkReport,
+    pub benches: Vec<BenchmarkReport>,
+    pub extra: String,
+}
 
 /// Metric struct that contains the name, unit and compute function for a metric
 /// A Metric is a measure of a specific performance aspect of a benchmark through
@@ -18,7 +30,7 @@ pub const BLOCK_TIME: u64 = 6;
 /// { name: "Average TPS", unit: "transactions/second", compute: average_tps }
 /// "Average TPS: 1000 transactions/second"
 #[derive(PartialEq, Eq, Hash, Clone)]
-pub struct Metric {
+pub struct NodeMetrics {
     pub name: &'static str,
     pub unit: &'static str,
     pub compute: fn(&[u64]) -> f64,
@@ -29,36 +41,43 @@ pub struct Metric {
 /// Example:
 /// MetricResult { name: "Average TPS", unit: "transactions/second", value: 1000 }
 /// "Average TPS: 1000 transactions/second"
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct MetricResult {
     pub name: &'static str,
     pub unit: &'static str,
-    pub value: f64,
+    pub value: serde_json::Value,
 }
 
-/// The simulation report.
-#[derive(Debug, Default, Clone)]
-pub struct GatlingReport {
-    pub benchmark_reports: Vec<BenchmarkReport>,
-}
-
-/// A benchmark report contains a name (used for displaying) and a vector of metric results
+/// A benchmark report contains a name and a vector of metric results
 /// of all the metrics that were computed for the benchmark
 /// A benchmark report can be created from a block range or from the last x blocks
 /// It implements the Serialize trait so it can be serialized to json
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct BenchmarkReport {
-    pub name: String,
+    #[serde(skip_serializing_if = "str::is_empty")]
+    pub name: &'static str,
+    pub amount: usize,
     pub metrics: Vec<MetricResult>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_x_blocks_metrics: Option<Vec<MetricResult>>,
 }
 
 impl BenchmarkReport {
-    pub async fn from_block_range<'a>(
-        starknet_rpc: Arc<JsonRpcClient<HttpTransport>>,
-        name: String,
+    pub fn new(name: &'static str, amount: usize) -> BenchmarkReport {
+        BenchmarkReport {
+            name,
+            amount,
+            metrics: Vec::new(),
+            last_x_blocks_metrics: None,
+        }
+    }
+
+    pub async fn with_block_range(
+        &mut self,
+        starknet_rpc: &JsonRpcClient<HttpTransport>,
         mut start_block: u64,
         mut end_block: u64,
-    ) -> Result<BenchmarkReport> {
+    ) -> Result<()> {
         // Whenever possible, skip the first and last blocks from the metrics
         // to make sure all the blocks used for calculating metrics are full
         if end_block - start_block > 2 {
@@ -67,60 +86,104 @@ impl BenchmarkReport {
         }
 
         let num_tx_per_block = get_num_tx_per_block(starknet_rpc, start_block, end_block).await?;
-        let metrics = compute_all_metrics(num_tx_per_block);
+        let metrics = compute_node_metrics(num_tx_per_block);
 
-        Ok(BenchmarkReport { name, metrics })
+        self.metrics.extend_from_slice(&metrics);
+
+        Ok(())
     }
 
-    pub async fn from_last_x_blocks<'a>(
-        starknet_rpc: Arc<JsonRpcClient<HttpTransport>>,
-        name: String,
+    pub async fn with_last_x_blocks(
+        &mut self,
+        starknet_rpc: &JsonRpcClient<HttpTransport>,
         num_blocks: u64,
-    ) -> Result<BenchmarkReport> {
+    ) -> Result<()> {
         // The last block won't be full of transactions, so we skip it
         let end_block = starknet_rpc.block_number().await? - 1;
         let start_block = end_block - num_blocks;
 
         let num_tx_per_block = get_num_tx_per_block(starknet_rpc, start_block, end_block).await?;
-        let metrics = compute_all_metrics(num_tx_per_block);
+        let metrics = compute_node_metrics(num_tx_per_block).to_vec();
 
-        Ok(BenchmarkReport { name, metrics })
+        self.last_x_blocks_metrics = Some(metrics);
+
+        Ok(())
     }
 
-    pub fn to_json(&self) -> Value {
-        let SysInfo {
-            os_name,
-            kernel_version,
-            arch,
-            cpu_count,
-            cpu_frequency,
-            cpu_brand,
-            memory,
-        } = SYSINFO.deref();
+    pub fn with_goose_metrics(&mut self, metrics: &GooseMetrics) -> Result<()> {
+        let scenario = metrics
+            .scenarios
+            .first()
+            .ok_or(eyre!("There is no scenario"))?;
 
-        let gigabyte_memory = memory / (1024 * 1024 * 1024);
+        let transactions = metrics
+            .transactions
+            .first()
+            .ok_or(eyre!("Could no find scenario's transactions"))?;
 
-        let sysinfo_string = format!(
-            "CPU Count: {cpu_count}\n\
-            CPU Model: {cpu_brand}\n\
-            CPU Speed (MHz): {cpu_frequency}\n\
-            Total Memory: {gigabyte_memory} GB\n\
-            Platform: {os_name}\n\
-            Release: {kernel_version}\n\
-            Architecture: {arch}",
-        );
+        let [_setup, requests, _finalizing, verification] = transactions.as_slice() else {
+            bail!("Failed at getting all transaction aggragates")
+        };
 
-        self.metrics
-            .iter()
-            .map(|metric| {
-                json!({
-                    "name": metric.name,
-                    "unit": metric.unit,
-                    "value": metric.value,
-                    "extra": sysinfo_string
-                })
-            })
-            .collect::<Value>()
+        let verification_requests = metrics
+            .requests
+            .get("POST Verification")
+            .ok_or(eyre!("Found no verification request metrics"))?;
+
+        self.metrics.extend_from_slice(&[
+            MetricResult {
+                name: "Total Submission Time",
+                unit: "milliseconds",
+                value: requests.total_time.into(),
+            },
+            MetricResult {
+                name: "Total Verification Time",
+                unit: "milliseconds",
+                value: verification.total_time.into(),
+            },
+            MetricResult {
+                name: "Failed Transactions Verifications",
+                unit: "",
+                value: verification_requests.fail_count.into(),
+            },
+            MetricResult {
+                name: "Failed Transaction Submissions",
+                unit: "",
+                value: requests.fail_count.into(),
+            },
+            MetricResult {
+                name: "Max Submission Time",
+                unit: "milliseconds",
+                value: requests.max_time.into(),
+            },
+            MetricResult {
+                name: "Min Submission Time",
+                unit: "milliseconds",
+                value: requests.min_time.into(),
+            },
+            MetricResult {
+                name: "Mean Submission Time",
+                unit: "milliseconds",
+                value: (requests.total_time as f64 / scenario.counter as f64).into(),
+            },
+            MetricResult {
+                name: "Max Verification Time",
+                unit: "milliseconds",
+                value: verification_requests.raw_data.maximum_time.into(),
+            },
+            MetricResult {
+                name: "Min Verification Time",
+                unit: "milliseconds",
+                value: verification_requests.raw_data.minimum_time.into(),
+            },
+            MetricResult {
+                name: "Mean Verification Time",
+                unit: "milliseconds",
+                value: (verification_requests.raw_data.total_time as f64 / scenario.counter as f64).into(),
+            },
+        ]);
+
+        Ok(())
     }
 }
 
@@ -134,16 +197,46 @@ impl fmt::Display for MetricResult {
 
 impl fmt::Display for BenchmarkReport {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let Self { name, metrics } = self;
+        let Self {
+            name,
+            amount,
+            metrics,
+            last_x_blocks_metrics: last_x_blocks,
+        } = self;
 
-        writeln!(f, "Benchmark Report: {name}")?;
+        writeln!(f, "Benchmark Report: {name} ({amount})")?;
 
         for metric in metrics {
             writeln!(f, "{metric}")?;
         }
 
+        if let Some(last_x_blocks) = last_x_blocks {
+            let len = last_x_blocks.len();
+
+            writeln!(f, "Last {len} block metrics:")?;
+
+            for metric in last_x_blocks {
+                writeln!(f, "{metric}")?;
+            }
+        }
+
         Ok(())
     }
+}
+
+pub fn compute_node_metrics(num_tx_per_block: Vec<u64>) -> [MetricResult; 2] {
+    [
+        MetricResult {
+            name: "Average TPS",
+            unit: "transactions/second",
+            value: average_tps(&num_tx_per_block).into(),
+        },
+        MetricResult {
+            name: "Average Extrinsics per block",
+            unit: "extrinsics/block",
+            value: average_tpb(&num_tx_per_block).into(),
+        },
+    ]
 }
 
 fn average_tps(num_tx_per_block: &[u64]) -> f64 {
@@ -153,30 +246,3 @@ fn average_tps(num_tx_per_block: &[u64]) -> f64 {
 fn average_tpb(num_tx_per_block: &[u64]) -> f64 {
     num_tx_per_block.iter().sum::<u64>() as f64 / num_tx_per_block.len() as f64
 }
-
-pub fn compute_all_metrics(num_tx_per_block: Vec<u64>) -> Vec<MetricResult> {
-    METRICS
-        .iter()
-        .map(|metric| {
-            let value = (metric.compute)(&num_tx_per_block);
-            MetricResult {
-                name: metric.name,
-                unit: metric.unit,
-                value,
-            }
-        })
-        .collect()
-}
-
-pub const METRICS: [Metric; 2] = [
-    Metric {
-        name: "Average TPS",
-        unit: "transactions/second",
-        compute: average_tps,
-    },
-    Metric {
-        name: "Average Extrinsics per block",
-        unit: "extrinsics/block",
-        compute: average_tpb,
-    },
-];

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -122,18 +122,16 @@ pub async fn wait_for_tx(
         }
 
         match provider.get_transaction_receipt(tx_hash).await {
-            Ok(Receipt(receipt)) => {
-                match receipt.execution_result() {
-                    ExecutionResult::Succeeded => {
-                        return Ok(());
-                    }
-                    ExecutionResult::Reverted { reason } => {
-                        return Err(eyre!(format!(
-                            "Transaction {tx_hash:#064x} has been rejected/reverted: {reason}"
-                        )));
-                    }
+            Ok(Receipt(receipt)) => match receipt.execution_result() {
+                ExecutionResult::Succeeded => {
+                    return Ok(());
                 }
-            }
+                ExecutionResult::Reverted { reason } => {
+                    return Err(eyre!(format!(
+                        "Transaction {tx_hash:#064x} has been rejected/reverted: {reason}"
+                    )));
+                }
+            },
             Ok(PendingReceipt(pending)) => {
                 if let ExecutionResult::Reverted { reason } = pending.execution_result() {
                     return Err(eyre!(format!(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -123,11 +123,6 @@ pub async fn wait_for_tx(
 
         match provider.get_transaction_receipt(tx_hash).await {
             Ok(Receipt(receipt)) => {
-                // Logic copied from starkli and the following comment too
-                // tWith JSON-RPC, once we get a receipt, the transaction must have been confirmed.
-                // Rejected transactions simply aren't available. This needs to be changed once we
-                // implement the sequencer fallback.
-
                 match receipt.execution_result() {
                     ExecutionResult::Succeeded => {
                         return Ok(());

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -64,6 +64,7 @@ pub struct SysInfo {
 }
 
 impl SysInfo {
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         let sys = System::new_all();
         let cpu = sys.global_cpu_info();
@@ -102,12 +103,6 @@ pub fn sysinfo_string() -> String {
         Release: {kernel_version}\n\
         Architecture: {arch}",
     )
-}
-
-impl Default for SysInfo {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 const WAIT_FOR_TX_TIMEOUT: Duration = Duration::from_secs(60);


### PR DESCRIPTION
This PR now makes shoot write to a reporting file, with information like average TPS as well as how long it took for requests to be sent and how many requests failed. This PR also improves error handling so that failed requests are properly recorded instead of panicing the goose user. The PR has been updated with added instructions and the structure of the output.

An example of the report.json output is attached [here](https://github.com/keep-starknet-strange/gomu-gomu-no-gatling/files/14384772/report.json).