### PR TITLE
ci: comment locking closed issues and prs on daily cron

### DIFF
--- a/.github/workflows/cron-daily.yml
+++ b/.github/workflows/cron-daily.yml
@@ -7,9 +7,11 @@ on:
     - cron: "0 0 * * *"
 
 jobs:
-  lock_closed:
-    name: Lock closed issues/PRs
-    uses: ./.github/workflows/lock-closed.yml
+  # Known issue on exceeding secondary rate limits
+  # https://github.com/dessant/lock-threads/issues/48
+  # lock_closed:
+  #   name: Lock closed issues/PRs
+  #   uses: ./.github/workflows/lock-closed.yml
 
   security_audit:
     name: Security audit


### PR DESCRIPTION
The daily cron is erroring frequently because of rate limiting. It seems to be a known issue with the official action. We should comment it temporarily.

https://github.com/keep-starknet-strange/gomu-gomu-no-gatling/actions/runs/8768585015
https://github.com/dessant/lock-threads/issues/48